### PR TITLE
allow main thread to exec instead of executor

### DIFF
--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -57,7 +57,9 @@ struct cvk_executor_thread {
     void wait_idle() {
         std::unique_lock<std::mutex> lock(m_lock);
         while (m_running) {
+            TRACE_BEGIN("wait_idle");
             m_running_cv.wait(lock);
+            TRACE_END();
         }
     }
 


### PR DESCRIPTION
Explicit inorder dependency between commands in order to allow main thread to steal commands from the executor when main thread reach a clFinish call, a clWaitForEvents call or a blocking enqueue command.

For clWaitForEvents, execute instead of executor only if all events are associated to one unique queue.

extract_cmds_dominated_by has a boolean to extract only non-batch commands. It will be very important when clvk will be able to use timeline semaphore.